### PR TITLE
パッケージ名を変更

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "growi-plugin-remark-youtube",
+  "name": "growi-plugin-google-calendar",
   "version": "1.0.0",
-  "description": "GROWI plugin template for script",
+  "description": "GROWI plugin for embed Google Calendar",
   "license": "MIT",
   "keywords": [
     "growi",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "growi-plugin-google-calendar",
+  "name": "growi-plugin-calendar-embed",
   "version": "1.0.0",
-  "description": "GROWI plugin for embed Google Calendar",
+  "description": "GROWI plugin for embed calendar",
   "license": "MIT",
   "keywords": [
     "growi",


### PR DESCRIPTION
パッケージ名が他のプラグインと競合しており、これをインストールした際に、既存の別のプラグインが上書きされるという現象が発生していたので、修正しました。